### PR TITLE
Refine Replicate page design

### DIFF
--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -118,98 +118,87 @@ export default function ReplicatePage() {
   const centerImageUrl = selectedImageUrl;
 
   return (
-    <div className="max-w-6xl mx-auto space-y-8">
-      <div className="text-center space-y-2">
-        <h1 className="text-4xl font-bold">
-          Imagino<span className="text-purple-500">.AI</span>
-        </h1>
-        <p className="text-gray-400">Gere imagens com modelos hospedados no Replicate.</p>
-      </div>
-
-      <div className="flex flex-col lg:flex-row gap-8 items-stretch">
-        {/* Painel esquerdo: prompt e controles */}
-        <div className="w-full lg:w-2/5 flex">
-          <div className="bg-gray-900/70 border border-gray-800 rounded-xl p-6 space-y-4 flex-1">
-            <div>
-              <label className="block mb-2 text-sm text-gray-300">Prompt</label>
-              <textarea
-                value={prompt}
-                onChange={e => setPrompt(e.target.value)}
-                placeholder="Descreva a imagem..."
-                className="w-full h-28 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-              />
+    <div className="h-screen w-full flex flex-col lg:flex-row">
+      {/* Painel esquerdo: prompt e controles */}
+      <div className="w-full lg:w-1/3 p-4 flex flex-col">
+        <label className="mb-2 text-sm text-gray-300">Prompt</label>
+        <div className="flex-1 flex flex-col">
+          <textarea
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            placeholder="Descreva a imagem..."
+            className="flex-1 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex gap-2">
+              {['1:1', '9:16', '16:9'].map(ratio => (
+                <button
+                  key={ratio}
+                  onClick={() => setSelectedAspectRatio(ratio)}
+                  className={`px-4 py-2 rounded-lg text-sm ${
+                    selectedAspectRatio === ratio
+                      ? 'bg-purple-600 text-white'
+                      : 'bg-gray-800 text-gray-300'
+                  } hover:bg-purple-500 transition`}
+                >
+                  {ratio}
+                </button>
+              ))}
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex gap-2">
-                {['1:1', '9:16', '16:9'].map(ratio => (
-                  <button
-                    key={ratio}
-                    onClick={() => setSelectedAspectRatio(ratio)}
-                    className={`px-4 py-2 rounded-lg text-sm ${
-                      selectedAspectRatio === ratio
-                        ? 'bg-purple-600 text-white'
-                        : 'bg-gray-800 text-gray-300'
-                    } hover:bg-purple-500 transition`}
-                  >
-                    {ratio}
-                  </button>
-                ))}
-              </div>
 
-              <button
-                onClick={handleGenerate}
-                disabled={loading || !token}
-                className="px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
-              >
-                {loading ? 'Gerando...' : 'Gerar'}
-              </button>
-            </div>
+            <button
+              onClick={handleGenerate}
+              disabled={loading || !token}
+              className="px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
+            >
+              {loading ? 'Gerando...' : 'Gerar'}
+            </button>
           </div>
         </div>
+      </div>
 
-        {/* Painel central: imagem selecionada ou estado de geração */}
-        <div className="flex-1 flex items-center justify-center">
-          {centerImageUrl ? (
-            <ImageCard
-              src={centerImageUrl}
-              loading={false}
-              onClick={() => {
-                setModalImage(centerImageUrl);
-                setModalPrompt(prompt);
-                setModalOpen(true);
-              }}
-            />
-          ) : loading ? (
-            <ImageCard loading={true} onClick={() => {}} />
-          ) : (
-            <div className="text-gray-500 italic text-center">
-              Digite um prompt e clique em &quot;Gerar&quot; para começar.
-            </div>
-          )}
-        </div>
-
-        {/* Painel direito: histórico */}
-        {images.filter(img => img.status === 'done' && img.url).length > 0 && (
-          <div className="w-full lg:w-1/6">
-            <h3 className="text-white mb-2">Histórico</h3>
-            <div className="flex flex-wrap lg:flex-col gap-2">
-              {images
-                .filter(img => img.status === 'done' && img.url)
-                .map(job => (
-                  <img
-                    key={job.id}
-                    src={job.url!}
-                    onClick={() => setSelectedImageUrl(job.url!)}
-                    className={`cursor-pointer rounded-md border-2 object-cover w-16 h-16 ${
-                      selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
-                    } hover:border-purple-400 transition`}
-                    alt=""
-                  />
-                ))}
-            </div>
+      {/* Painel central: imagem selecionada ou estado de geração */}
+      <div className="flex-1 p-4 flex items-center justify-center">
+        {centerImageUrl ? (
+          <ImageCard
+            src={centerImageUrl}
+            loading={false}
+            onClick={() => {
+              setModalImage(centerImageUrl);
+              setModalPrompt(prompt);
+              setModalOpen(true);
+            }}
+          />
+        ) : loading ? (
+          <ImageCard loading={true} onClick={() => {}} />
+        ) : (
+          <div className="text-gray-500 italic text-center">
+            Digite um prompt e clique em &quot;Gerar&quot; para começar.
           </div>
         )}
       </div>
+
+      {/* Painel direito: histórico */}
+      {images.filter(img => img.status === 'done' && img.url).length > 0 && (
+        <div className="w-full lg:w-1/5 p-4">
+          <h3 className="text-white mb-2">Histórico</h3>
+          <div className="grid grid-cols-3 sm:grid-cols-6 lg:grid-cols-1 gap-2 overflow-y-auto">
+            {images
+              .filter(img => img.status === 'done' && img.url)
+              .map(job => (
+                <img
+                  key={job.id}
+                  src={job.url!}
+                  onClick={() => setSelectedImageUrl(job.url!)}
+                  className={`cursor-pointer rounded-md border-2 object-cover w-24 h-24 ${
+                    selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
+                  } hover:border-purple-400 transition`}
+                  alt=""
+                />
+              ))}
+          </div>
+        </div>
+      )}
 
       {/* Modal para ampliar imagem */}
       <ImageCardModal

--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -126,86 +126,90 @@ export default function ReplicatePage() {
         <p className="text-gray-400">Gere imagens com modelos hospedados no Replicate.</p>
       </div>
 
-      {/* Bloco de prompt e controles */}
-      <div className="bg-gray-900/70 border border-gray-800 rounded-xl p-6 space-y-4">
-        <div>
-          <label className="block mb-2 text-sm text-gray-300">Prompt</label>
-          <textarea
-            value={prompt}
-            onChange={e => setPrompt(e.target.value)}
-            placeholder="Descreva a imagem..."
-            className="w-full h-28 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-        </div>
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex gap-2">
-            {['1:1', '9:16', '16:9'].map(ratio => (
+      <div className="flex flex-col lg:flex-row gap-8">
+        {/* Painel esquerdo: prompt e controles */}
+        <div className="w-full lg:w-1/3">
+          <div className="bg-gray-900/70 border border-gray-800 rounded-xl p-6 space-y-4">
+            <div>
+              <label className="block mb-2 text-sm text-gray-300">Prompt</label>
+              <textarea
+                value={prompt}
+                onChange={e => setPrompt(e.target.value)}
+                placeholder="Descreva a imagem..."
+                className="w-full h-28 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex gap-2">
+                {['1:1', '9:16', '16:9'].map(ratio => (
+                  <button
+                    key={ratio}
+                    onClick={() => setSelectedAspectRatio(ratio)}
+                    className={`px-4 py-2 rounded-lg text-sm ${
+                      selectedAspectRatio === ratio
+                        ? 'bg-purple-600 text-white'
+                        : 'bg-gray-800 text-gray-300'
+                    } hover:bg-purple-500 transition`}
+                  >
+                    {ratio}
+                  </button>
+                ))}
+              </div>
+
               <button
-                key={ratio}
-                onClick={() => setSelectedAspectRatio(ratio)}
-                className={`px-4 py-2 rounded-lg text-sm ${
-                  selectedAspectRatio === ratio
-                    ? 'bg-purple-600 text-white'
-                    : 'bg-gray-800 text-gray-300'
-                } hover:bg-purple-500 transition`}
+                onClick={handleGenerate}
+                disabled={loading || !token}
+                className="px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
               >
-                {ratio}
+                {loading ? 'Gerando...' : 'Gerar'}
               </button>
-            ))}
+            </div>
           </div>
-
-          <button
-            onClick={handleGenerate}
-            disabled={loading || !token}
-            className="px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
-          >
-            {loading ? 'Gerando...' : 'Gerar'}
-          </button>
         </div>
-      </div>
 
-      {/* Exibição da imagem gerada */}
-      <div className="flex justify-center">
-        {centerImageUrl ? (
-          <ImageCard
-            src={centerImageUrl}
-            loading={false}
-            onClick={() => {
-              setModalImage(centerImageUrl);
-              setModalPrompt(prompt);
-              setModalOpen(true);
-            }}
-          />
-        ) : loading ? (
-          <ImageCard loading={true} onClick={() => {}} />
-        ) : (
-          <div className="text-gray-500 italic text-center">
-            Digite um prompt e clique em &quot;Gerar&quot; para começar.
+        {/* Painel central: imagem selecionada ou estado de geração */}
+        <div className="flex-1 flex items-center justify-center">
+          {centerImageUrl ? (
+            <ImageCard
+              src={centerImageUrl}
+              loading={false}
+              onClick={() => {
+                setModalImage(centerImageUrl);
+                setModalPrompt(prompt);
+                setModalOpen(true);
+              }}
+            />
+          ) : loading ? (
+            <ImageCard loading={true} onClick={() => {}} />
+          ) : (
+            <div className="text-gray-500 italic text-center">
+              Digite um prompt e clique em &quot;Gerar&quot; para começar.
+            </div>
+          )}
+        </div>
+
+        {/* Painel direito: histórico */}
+        {images.filter(img => img.status === 'done' && img.url).length > 0 && (
+          <div className="w-full lg:w-1/6">
+            <h3 className="text-white mb-2">Histórico</h3>
+            <div className="grid grid-cols-3 lg:grid-cols-1 gap-4">
+              {images
+                .filter(img => img.status === 'done' && img.url)
+                .map(job => (
+                  <img
+                    key={job.id}
+                    src={job.url!}
+                    onClick={() => setSelectedImageUrl(job.url!)}
+                    className={`cursor-pointer rounded-md border-2 object-cover w-full h-24 ${
+                      selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
+                    } hover:border-purple-400 transition`}
+                    alt=""
+                  />
+                ))}
+            </div>
           </div>
         )}
       </div>
-
-      {/* Histórico de imagens */}
-      {images.filter(img => img.status === 'done' && img.url).length > 0 && (
-        <div>
-          <h3 className="text-white mb-2">Histórico</h3>
-          <div className="grid grid-cols-3 sm:grid-cols-6 gap-4">
-            {images
-              .filter(img => img.status === 'done' && img.url)
-              .map(job => (
-                <img
-                  key={job.id}
-                  src={job.url!}
-                  onClick={() => setSelectedImageUrl(job.url!)}
-                  className={`cursor-pointer rounded-md border-2 object-cover w-full h-24 ${
-                    selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
-                  } hover:border-purple-400 transition`}
-                  alt=""
-                />
-              ))}
-          </div>
-        </div>
-      )}
 
       {/* Modal para ampliar imagem */}
       <ImageCardModal

--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -18,6 +18,7 @@ import { normalizeUrl } from '../../../lib/api';
 export default function ReplicatePage() {
   const [prompt, setPrompt] = useState('');
   const [selectedAspectRatio, setSelectedAspectRatio] = useState('1:1');
+  const [quality, setQuality] = useState(3);
   const [images, setImages] = useState<UiJob[]>([]);
   const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -120,40 +121,56 @@ export default function ReplicatePage() {
   return (
     <div className="h-screen w-full flex flex-col lg:flex-row">
       {/* Painel esquerdo: prompt e controles */}
-      <div className="w-full lg:w-1/3 p-4 flex flex-col">
+      <div className="w-full lg:w-1/3 p-4 flex flex-col h-full">
         <label className="mb-2 text-sm text-gray-300">Prompt</label>
-        <div className="flex-1 flex flex-col">
-          <textarea
-            value={prompt}
-            onChange={e => setPrompt(e.target.value)}
-            placeholder="Descreva a imagem..."
-            className="flex-1 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
-            <div className="flex gap-2">
-              {['1:1', '9:16', '16:9'].map(ratio => (
-                <button
-                  key={ratio}
-                  onClick={() => setSelectedAspectRatio(ratio)}
-                  className={`px-4 py-2 rounded-lg text-sm ${
-                    selectedAspectRatio === ratio
-                      ? 'bg-purple-600 text-white'
-                      : 'bg-gray-800 text-gray-300'
-                  } hover:bg-purple-500 transition`}
-                >
-                  {ratio}
-                </button>
-              ))}
-            </div>
-
-            <button
-              onClick={handleGenerate}
-              disabled={loading || !token}
-              className="px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
-            >
-              {loading ? 'Gerando...' : 'Gerar'}
-            </button>
+        <textarea
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          placeholder="Descreva a imagem..."
+          className="h-1/3 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+        <div className="mt-4 flex-1 flex flex-col gap-4">
+          <div className="flex gap-2">
+            {['1:1', '9:16', '16:9'].map(ratio => (
+              <button
+                key={ratio}
+                onClick={() => setSelectedAspectRatio(ratio)}
+                className={`px-4 py-2 rounded-lg text-sm ${
+                  selectedAspectRatio === ratio
+                    ? 'bg-purple-600 text-white'
+                    : 'bg-gray-800 text-gray-300'
+                } hover:bg-purple-500 transition`}
+              >
+                {ratio}
+              </button>
+            ))}
           </div>
+
+          <div>
+            <label className="text-sm text-gray-300 mb-1 block">
+              Velocidade x Qualidade ({quality})
+            </label>
+            <input
+              type="range"
+              min={1}
+              max={5}
+              value={quality}
+              onChange={e => setQuality(Number(e.target.value))}
+              className="w-full"
+            />
+            <div className="flex justify-between text-xs text-gray-400">
+              <span>Rápido</span>
+              <span>Qualidade</span>
+            </div>
+          </div>
+
+          <button
+            onClick={handleGenerate}
+            disabled={loading || !token}
+            className="mt-auto px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
+          >
+            {loading ? 'Gerando...' : 'Gerar'}
+          </button>
         </div>
       </div>
 

--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -126,10 +126,10 @@ export default function ReplicatePage() {
         <p className="text-gray-400">Gere imagens com modelos hospedados no Replicate.</p>
       </div>
 
-      <div className="flex flex-col lg:flex-row gap-8">
+      <div className="flex flex-col lg:flex-row gap-8 items-stretch">
         {/* Painel esquerdo: prompt e controles */}
-        <div className="w-full lg:w-1/3">
-          <div className="bg-gray-900/70 border border-gray-800 rounded-xl p-6 space-y-4">
+        <div className="w-full lg:w-2/5 flex">
+          <div className="bg-gray-900/70 border border-gray-800 rounded-xl p-6 space-y-4 flex-1">
             <div>
               <label className="block mb-2 text-sm text-gray-300">Prompt</label>
               <textarea
@@ -192,7 +192,7 @@ export default function ReplicatePage() {
         {images.filter(img => img.status === 'done' && img.url).length > 0 && (
           <div className="w-full lg:w-1/6">
             <h3 className="text-white mb-2">Histórico</h3>
-            <div className="grid grid-cols-3 lg:grid-cols-1 gap-4">
+            <div className="flex flex-wrap lg:flex-col gap-2">
               {images
                 .filter(img => img.status === 'done' && img.url)
                 .map(job => (
@@ -200,7 +200,7 @@ export default function ReplicatePage() {
                     key={job.id}
                     src={job.url!}
                     onClick={() => setSelectedImageUrl(job.url!)}
-                    className={`cursor-pointer rounded-md border-2 object-cover w-full h-24 ${
+                    className={`cursor-pointer rounded-md border-2 object-cover w-16 h-16 ${
                       selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
                     } hover:border-purple-400 transition`}
                     alt=""

--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -59,100 +59,113 @@ export default function ReplicatePage() {
     setLoading(true);
     setSelectedImageUrl(null);
 
-  const jobId = await createReplicateJob(prompt, selectedAspectRatio, token);    
+    const jobId = await createReplicateJob(prompt, selectedAspectRatio, token);
     const newJob: UiJob = {
       id: jobId,
       status: 'loading',
       url: null,
-      aspectRatio: selectedAspectRatio
+      aspectRatio: selectedAspectRatio,
     };
-    
+
     setImages((prev: UiJob[]) => [newJob, ...prev]);
 
     const poll = setInterval(async () => {
-    const content = await getJobStatus(jobId, token);
-    if (!content) return;
-    const status = content.status?.toUpperCase();
+      const content = await getJobStatus(jobId, token);
+      if (!content) return;
+      const status = content.status?.toUpperCase();
 
-    const rawUrl = content.imageUrl ?? (Array.isArray(content.imageUrls) ? content.imageUrls[0] : null);
+      const rawUrl =
+        content.imageUrl ?? (Array.isArray(content.imageUrls) ? content.imageUrls[0] : null);
 
-    if (status === 'COMPLETED') {
-      clearInterval(poll);
+      if (status === 'COMPLETED') {
+        clearInterval(poll);
 
-      const fullUrl = normalizeUrl(rawUrl);
+        const fullUrl = normalizeUrl(rawUrl);
 
-      setImages((prev: UiJob[]) =>
-        prev.map((j: UiJob) => (j.id === jobId ? { ...j, status: 'done', url: fullUrl } : j))
-      );
-      setSelectedImageUrl(fullUrl);
+        setImages((prev: UiJob[]) =>
+          prev.map((j: UiJob) => (j.id === jobId ? { ...j, status: 'done', url: fullUrl } : j))
+        );
+        setSelectedImageUrl(fullUrl);
 
-      setHistory((prev: ImageJobApi[]) => [
-        {
-          id: jobId,
-          jobId,
-          prompt,
-          userId: 'me',
-          status: 'done',
-          imageUrl: rawUrl,          // mantém como veio (sem normalizar) — o map normaliza
-          imageUrls: content.imageUrls ?? (rawUrl ? [rawUrl] : []),
-          aspectRatio: selectedAspectRatio,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        },
-        ...prev,
-      ]);
+        setHistory((prev: ImageJobApi[]) => [
+          {
+            id: jobId,
+            jobId,
+            prompt,
+            userId: 'me',
+            status: 'done',
+            imageUrl: rawUrl, // mantém como veio (sem normalizar) — o map normaliza
+            imageUrls: content.imageUrls ?? (rawUrl ? [rawUrl] : []),
+            aspectRatio: selectedAspectRatio,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          ...prev,
+        ]);
 
-      setLoading(false);
-    }
+        setLoading(false);
+      }
 
-    if (status === 'FAILED') {
-      clearInterval(poll);
-      setImages(prev => prev.map(j => (j.id === jobId ? { ...j, status: 'done' } : j)));
-      setLoading(false);
-    }
-  }, 2000);
+      if (status === 'FAILED') {
+        clearInterval(poll);
+        setImages(prev => prev.map(j => (j.id === jobId ? { ...j, status: 'done' } : j)));
+        setLoading(false);
+      }
+    }, 2000);
   }
 
   // escolhe a imagem a ser exibida no centro
   const centerImageUrl = selectedImageUrl;
 
   return (
-    <div className="flex flex-col lg:flex-row space-y-8 lg:space-y-0 lg:space-x-8">
-      {/* Painel esquerdo: prompt e controles */}
-      <div className="w-full lg:w-1/3 space-y-4">
+    <div className="max-w-6xl mx-auto space-y-8">
+      <div className="text-center space-y-2">
+        <h1 className="text-4xl font-bold">
+          Imagino<span className="text-purple-500">.AI</span>
+        </h1>
+        <p className="text-gray-400">Gere imagens com modelos hospedados no Replicate.</p>
+      </div>
+
+      {/* Bloco de prompt e controles */}
+      <div className="bg-gray-900/70 border border-gray-800 rounded-xl p-6 space-y-4">
         <div>
-          <label className="block text-white mb-2">Prompt</label>
+          <label className="block mb-2 text-sm text-gray-300">Prompt</label>
           <textarea
             value={prompt}
             onChange={e => setPrompt(e.target.value)}
             placeholder="Descreva a imagem..."
-            className="w-full h-28 p-3 rounded-md bg-gray-800 text-white resize-none"
+            className="w-full h-28 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
           />
         </div>
-        <div className="flex space-x-2">
-          {['1:1', '9:16', '16:9'].map(ratio => (
-            <button
-              key={ratio}
-              onClick={() => setSelectedAspectRatio(ratio)}
-              className={`px-4 py-2 rounded-md ${
-                selectedAspectRatio === ratio ? 'bg-purple-600' : 'bg-gray-800'
-              }`}
-            >
-              {ratio}
-            </button>
-          ))}
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex gap-2">
+            {['1:1', '9:16', '16:9'].map(ratio => (
+              <button
+                key={ratio}
+                onClick={() => setSelectedAspectRatio(ratio)}
+                className={`px-4 py-2 rounded-lg text-sm ${
+                  selectedAspectRatio === ratio
+                    ? 'bg-purple-600 text-white'
+                    : 'bg-gray-800 text-gray-300'
+                } hover:bg-purple-500 transition`}
+              >
+                {ratio}
+              </button>
+            ))}
+          </div>
+
+          <button
+            onClick={handleGenerate}
+            disabled={loading || !token}
+            className="px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
+          >
+            {loading ? 'Gerando...' : 'Gerar'}
+          </button>
         </div>
-        <button
-          onClick={handleGenerate}
-          disabled={loading || !token}   // <<<<<< desabilita se não logado
-          className="w-full py-2 rounded-md bg-purple-600 hover:bg-purple-700 text-white font-semibold"
-        >
-          {loading ? 'Gerando...' : 'Gerar Imagem'}
-        </button>
       </div>
 
-      {/* Painel central: imagem selecionada ou estado de geração */}
-      <div className="w-full lg:w-2/3 flex items-center justify-center">
+      {/* Exibição da imagem gerada */}
+      <div className="flex justify-center">
         {centerImageUrl ? (
           <ImageCard
             src={centerImageUrl}
@@ -166,31 +179,33 @@ export default function ReplicatePage() {
         ) : loading ? (
           <ImageCard loading={true} onClick={() => {}} />
         ) : (
-          <div className="text-gray-500 italic">
-            Clique em &quot;Gerar Imagem&quot; para começar.
+          <div className="text-gray-500 italic text-center">
+            Digite um prompt e clique em &quot;Gerar&quot; para começar.
           </div>
         )}
       </div>
 
-      {/* Painel direito: histórico em fila */}
-      <div className="w-full lg:w-1/6">
-        <h3 className="text-white mb-2">Histórico</h3>
-        <div className="flex lg:flex-col space-x-4 lg:space-x-0 lg:space-y-4 overflow-x-auto">
-          {images
-            .filter(img => img.status === 'done' && img.url)
-            .map(job => (
-              <img
-                key={job.id}
-                src={job.url!}
-                onClick={() => setSelectedImageUrl(job.url!)}
-                className={`cursor-pointer rounded-md border-2 w-[80px] h-[80px] object-cover ${
-                  selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
-                } hover:border-purple-400 transition`}
-                alt=""
-              />
-            ))}
+      {/* Histórico de imagens */}
+      {images.filter(img => img.status === 'done' && img.url).length > 0 && (
+        <div>
+          <h3 className="text-white mb-2">Histórico</h3>
+          <div className="grid grid-cols-3 sm:grid-cols-6 gap-4">
+            {images
+              .filter(img => img.status === 'done' && img.url)
+              .map(job => (
+                <img
+                  key={job.id}
+                  src={job.url!}
+                  onClick={() => setSelectedImageUrl(job.url!)}
+                  className={`cursor-pointer rounded-md border-2 object-cover w-full h-24 ${
+                    selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
+                  } hover:border-purple-400 transition`}
+                  alt=""
+                />
+              ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Modal para ampliar imagem */}
       <ImageCardModal

--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -129,7 +129,7 @@ export default function ReplicatePage() {
           placeholder="Descreva a imagem..."
           className="h-1/3 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
         />
-        <div className="mt-4 flex-1 flex flex-col gap-4">
+        <div className="mt-4 flex flex-col gap-4">
           <div className="flex gap-2">
             {['1:1', '9:16', '16:9'].map(ratio => (
               <button
@@ -167,7 +167,7 @@ export default function ReplicatePage() {
           <button
             onClick={handleGenerate}
             disabled={loading || !token}
-            className="mt-auto px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
+            className="mt-2 px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
           >
             {loading ? 'Gerando...' : 'Gerar'}
           </button>

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -13,19 +13,19 @@ export default function ImageCard({ src, loading, onClick }: Props) {
 
   return (
     <div
-      className="relative w-full h-full min-h-[300px] rounded-xl overflow-hidden shadow-lg border border-gray-800 cursor-pointer group transform transition-transform duration-200 hover:scale-105"
+      className="relative inline-block max-w-full max-h-[80vh] rounded-xl overflow-hidden shadow-lg border border-gray-800 cursor-pointer group transform transition-transform duration-200 hover:scale-105"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onClick={onClick}
     >
       {/* Imagem quando carregada */}
       {src && !loading && (
-        <img src={src} alt="Imagem" className="w-full h-full object-cover" />
+        <img src={src} alt="Imagem" className="w-auto h-auto max-w-full max-h-[80vh] object-contain" />
       )}
 
       {/* Placeholder de carregamento */}
       {loading && (
-        <div className="flex items-center justify-center w-full h-full text-sm text-muted-foreground">
+        <div className="flex items-center justify-center w-72 h-72 text-sm text-muted-foreground">
           Gerando imagem...
         </div>
       )}
@@ -37,7 +37,7 @@ export default function ImageCard({ src, loading, onClick }: Props) {
           download={`imagem-${Date.now()}.png`}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
+          onClick={e => e.stopPropagation()}
           className="absolute top-2 right-2 z-10 bg-black/60 p-2 rounded-full text-white hover:bg-black/80 transition"
         >
           <Download size={18} />

--- a/src/components/ImageCardModal.tsx
+++ b/src/components/ImageCardModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import React from 'react';
 
 type Props = {
   isOpen: boolean;
@@ -10,38 +10,18 @@ type Props = {
 };
 
 export default function ImageCardModal({ isOpen, onClose, src, prompt }: Props) {
-  const modalRef = useRef<HTMLDivElement>(null); // ✅ Agora está no lugar certo
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen, onClose]);
-
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center px-4">
+    <div className="fixed inset-0 z-50 bg-black flex flex-col" onClick={onClose}>
+      <div className="flex-1 flex items-center justify-center overflow-auto" onClick={e => e.stopPropagation()}>
+        <img src={src} alt="Imagem completa" className="max-w-full max-h-full object-contain" />
+      </div>
       <div
-        ref={modalRef}
-        className="bg-gray-900 rounded-xl p-6 w-full max-w-3xl shadow-2xl relative"
+        className="p-4 text-gray-300 text-sm border-t border-gray-700 overflow-auto"
+        onClick={e => e.stopPropagation()}
       >
-        <img
-          src={src}
-          alt="Imagem completa"
-          className="w-full h-auto rounded-md mb-4"
-        />
-        <p className="text-gray-300 text-sm whitespace-pre-line break-words">{prompt}</p>
+        {prompt}
       </div>
     </div>
   );

--- a/src/components/ImageCardModal.tsx
+++ b/src/components/ImageCardModal.tsx
@@ -14,8 +14,13 @@ export default function ImageCardModal({ isOpen, onClose, src, prompt }: Props) 
 
   return (
     <div className="fixed inset-0 z-50 bg-black flex flex-col" onClick={onClose}>
-      <div className="flex-1 flex items-center justify-center overflow-auto" onClick={e => e.stopPropagation()}>
-        <img src={src} alt="Imagem completa" className="max-w-full max-h-full object-contain" />
+      <div className="flex-1 flex items-center justify-center overflow-auto">
+        <img
+          src={src}
+          alt="Imagem completa"
+          className="max-w-full max-h-full object-contain"
+          onClick={e => e.stopPropagation()}
+        />
       </div>
       <div
         className="p-4 text-gray-300 text-sm border-t border-gray-700 overflow-auto"


### PR DESCRIPTION
## Summary
- redesign Replicate image page with centered header and modern prompt controls
- show generated image and history grid in a cleaner layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a88ab06c8832fa15b52b6f6d2689b