### PR TITLE
feat: support username and phone number fields

### DIFF
--- a/src/app/google-auth/page.tsx
+++ b/src/app/google-auth/page.tsx
@@ -11,8 +11,9 @@ export default function GoogleAuthPage() {
 
   useEffect(() => {
     const token = params.get('token');
-    if (token && auth) {
-      auth.login(token);
+    const username = params.get('username');
+    if (token && username && auth) {
+      auth.login(token, username);
       router.push('/images/replicate');
     } else {
       router.push('/login');

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -14,7 +14,7 @@ vi.mock('next/navigation', () => ({
 
 describe('LoginPage interactions', () => {
   const renderPage = () => {
-    const auth = { token: null, isAuthenticated: false, login: vi.fn(), logout: vi.fn() };
+    const auth = { token: null, username: null, isAuthenticated: false, login: vi.fn(), logout: vi.fn(), setUsername: vi.fn() };
     render(
       <AuthContext.Provider value={auth}>
         <LoginPage />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,11 +19,11 @@ export default function LoginPage() {
     e.preventDefault();
     if (!auth) return;
     try {
-      const { token } = await loginUser(email, password);
-      auth.login(token);
+      const { token, username } = await loginUser(email, password);
+      auth.login(token, username);
       router.push('/images/replicate');
     } catch (err: unknown) {
-      setError('Erro ao entrar');
+      setError(err instanceof Error ? err.message : 'Erro ao entrar');
     }
   };
 

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -11,21 +11,26 @@ import { AuthContext } from '../../context/AuthContext';
 export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
   const [error, setError] = useState('');
   const router = useRouter();
   const auth = useContext(AuthContext);
 
   const handleSubmit = async (e: React.FormEvent) => {
-  e.preventDefault();
-  if (!auth) return;
-  try {
-    const { token } = await registerUser(email, password);
-    auth.login(token);
-    router.push('/images/replicate');
-  } catch (err: unknown) {
-    setError('Erro ao entrar');
-  }
-};
+    e.preventDefault();
+    if (!auth) return;
+    try {
+      const { token, username: returnedUsername } = await registerUser(
+        email,
+        password,
+        username || undefined,
+      );
+      auth.login(token, returnedUsername);
+      router.push('/images/replicate');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Erro ao entrar');
+    }
+  };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-900 px-4 py-8">
@@ -37,6 +42,13 @@ export default function RegisterPage() {
         {error && <p className="text-red-500 mb-4 text-center">{error}</p>}
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            placeholder="Username (opcional)"
+            className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400 focus:outline-none"
+          />
           <input
             type="email"
             value={email}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,7 +12,7 @@ export default function Navbar() {
 
   if (!auth) return null;
 
-  const { isAuthenticated, logout } = auth;
+  const { isAuthenticated, logout, username } = auth;
 
   const handleLogout = () => {
     logout();
@@ -49,7 +49,7 @@ export default function Navbar() {
               onClick={() => setMenuOpen((o) => !o)}
               className="w-8 h-8 flex items-center justify-center rounded-full bg-purple-600 text-white"
             >
-              U {/* Pode trocar por ícone ou inicial do usuário */}
+              {(username?.[0] ?? 'U').toUpperCase()}
             </button>
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 bg-gray-800 rounded-lg shadow-lg z-50">

--- a/src/components/profile/UserInfo.tsx
+++ b/src/components/profile/UserInfo.tsx
@@ -1,25 +1,81 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useAuth } from '../../context/AuthContext';
+import { getUserProfile, updateUser } from '../../lib/api';
 
 export default function UserInfo() {
-  const [form, setForm] = useState({ name: '', email: '' });
+  const { token, setUsername } = useAuth();
+  const [form, setForm] = useState({ username: '', phoneNumber: '' });
+  const [initial, setInitial] = useState({ username: '', phoneNumber: '' });
+  const [userId, setUserId] = useState('');
   const [saved, setSaved] = useState(false);
   const [visible, setVisible] = useState(false);
+  const [error, setError] = useState('');
 
   useEffect(() => setVisible(true), []);
+
+  useEffect(() => {
+    async function load() {
+      if (!token) return;
+      try {
+        const profile = await getUserProfile(token);
+        setForm({
+          username: profile.username || '',
+          phoneNumber: profile.phoneNumber || '',
+        });
+        setInitial({
+          username: profile.username || '',
+          phoneNumber: profile.phoneNumber || '',
+        });
+        setUserId(profile.id);
+        if (profile.username) setUsername(profile.username);
+      } catch {
+        setError('Erro ao carregar usuário');
+      }
+    }
+    load();
+  }, [token, setUsername]);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
+    setForm(prev => ({ ...prev, [name]: value }));
     setSaved(false);
+    setError('');
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setSaved(true);
+    if (!token || !userId) return;
+    if (!form.username.trim()) {
+      setError('Username não pode ficar vazio');
+      return;
+    }
+    const data: { username?: string; phoneNumber?: string | null } = {};
+    if (form.username !== initial.username) data.username = form.username;
+    if (form.phoneNumber !== initial.phoneNumber)
+      data.phoneNumber = form.phoneNumber || null;
+    if (Object.keys(data).length === 0) {
+      setSaved(true);
+      return;
+    }
+    try {
+      const updated = await updateUser(userId, data, token);
+      setForm({
+        username: updated.username || '',
+        phoneNumber: updated.phoneNumber || '',
+      });
+      setInitial({
+        username: updated.username || '',
+        phoneNumber: updated.phoneNumber || '',
+      });
+      setUsername(updated.username);
+      setSaved(true);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Erro ao salvar');
+    }
   };
 
   return (
@@ -30,29 +86,28 @@ export default function UserInfo() {
       } transition-opacity duration-300 space-y-4`}
     >
       <div>
-        <label className="block text-sm mb-1" htmlFor="name">
-          Nome
+        <label className="block text-sm mb-1" htmlFor="username">
+          Username
         </label>
         <input
-          id="name"
-          name="name"
-          value={form.name}
+          id="username"
+          name="username"
+          value={form.username}
           onChange={handleChange}
-          placeholder="Seu nome"
+          placeholder="Seu username"
           className="w-full bg-gray-900/40 border border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 transition"
         />
       </div>
       <div>
-        <label className="block text-sm mb-1" htmlFor="email">
-          E-mail
+        <label className="block text-sm mb-1" htmlFor="phoneNumber">
+          Telefone
         </label>
         <input
-          id="email"
-          type="email"
-          name="email"
-          value={form.email}
+          id="phoneNumber"
+          name="phoneNumber"
+          value={form.phoneNumber}
           onChange={handleChange}
-          placeholder="voce@exemplo.com"
+          placeholder="(99) 99999-9999"
           className="w-full bg-gray-900/40 border border-gray-700 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500 transition"
         />
       </div>
@@ -65,7 +120,7 @@ export default function UserInfo() {
       {saved && (
         <p className="text-green-400 text-sm">Informações atualizadas!</p>
       )}
+      {error && <p className="text-red-400 text-sm">{error}</p>}
     </form>
   );
 }
-

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,45 +1,59 @@
 'use client';
 
-import { createContext, useState, useEffect, ReactNode, useContext  } from 'react';
+import { createContext, useState, useEffect, ReactNode, useContext } from 'react';
 
 interface AuthContextType {
   token: string | null;
+  username: string | null;
   isAuthenticated: boolean;
-  login: (token: string) => void;
+  login: (token: string, username: string) => void;
   logout: () => void;
+  setUsername: (username: string) => void;
 }
 
 export const AuthContext = createContext<AuthContextType | null>(null);
 
-
-
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
+  const [username, setUsernameState] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  // Carrega o token do localStorage na inicialização
+  // Carrega o token e o username do localStorage na inicialização
   useEffect(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
-    if (stored) {
-      setToken(stored);
+    const storedToken = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    const storedUsername = typeof window !== 'undefined' ? localStorage.getItem('username') : null;
+    if (storedToken) {
+      setToken(storedToken);
       setIsAuthenticated(true);
+    }
+    if (storedUsername) {
+      setUsernameState(storedUsername);
     }
   }, []);
 
-  const login = (newToken: string) => {
+  const login = (newToken: string, newUsername: string) => {
     localStorage.setItem('token', newToken);
+    localStorage.setItem('username', newUsername);
     setToken(newToken);
+    setUsernameState(newUsername);
     setIsAuthenticated(true);
   };
 
   const logout = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('username');
     setToken(null);
+    setUsernameState(null);
     setIsAuthenticated(false);
   };
 
+  const setUsername = (newUsername: string) => {
+    localStorage.setItem('username', newUsername);
+    setUsernameState(newUsername);
+  };
+
   return (
-    <AuthContext.Provider value={{ token, isAuthenticated, login, logout }}>
+    <AuthContext.Provider value={{ token, username, isAuthenticated, login, logout, setUsername }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- persist username in auth context alongside token
- handle username on register, login and Google OAuth
- allow editing username and phone number in profile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e0a56ce54832f902bc158f5aa2755