### PR TITLE
Enhance UI with animations and hover effects

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,11 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fade-in {
+  animation: fadeIn 0.5s ease-out forwards;
+}

--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -119,15 +119,15 @@ export default function ReplicatePage() {
   const centerImageUrl = selectedImageUrl;
 
   return (
-    <div className="h-screen w-full flex flex-col lg:flex-row">
+    <div className="h-screen w-full flex flex-col lg:flex-row bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 animate-fade-in">
       {/* Painel esquerdo: prompt e controles */}
-      <div className="w-full lg:w-1/3 p-4 flex flex-col h-full">
+      <div className="w-full lg:w-1/3 p-4 flex flex-col h-full bg-black/30 backdrop-blur-md animate-fade-in">
         <label className="mb-2 text-sm text-gray-300">Prompt</label>
         <textarea
           value={prompt}
           onChange={e => setPrompt(e.target.value)}
           placeholder="Descreva a imagem..."
-          className="h-1/3 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+          className="h-1/3 p-3 rounded-md bg-gray-800 text-white resize-none placeholder-gray-500 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors hover:bg-gray-700"
         />
         <div className="mt-4 flex flex-col gap-4">
           <div className="flex gap-2">
@@ -135,11 +135,11 @@ export default function ReplicatePage() {
               <button
                 key={ratio}
                 onClick={() => setSelectedAspectRatio(ratio)}
-                className={`px-4 py-2 rounded-lg text-sm ${
+                className={`px-4 py-2 rounded-lg text-sm transition-all transform hover:scale-105 ${
                   selectedAspectRatio === ratio
                     ? 'bg-purple-600 text-white'
                     : 'bg-gray-800 text-gray-300'
-                } hover:bg-purple-500 transition`}
+                } hover:bg-purple-500`}
               >
                 {ratio}
               </button>
@@ -167,7 +167,7 @@ export default function ReplicatePage() {
           <button
             onClick={handleGenerate}
             disabled={loading || !token}
-            className="mt-2 px-6 py-3 bg-purple-600 text-white font-medium rounded-xl hover:bg-purple-700 transition disabled:opacity-50"
+            className="mt-2 px-6 py-3 bg-purple-600 text-white font-medium rounded-xl transition-all duration-300 transform hover:bg-purple-700 hover:scale-105 disabled:opacity-50"
           >
             {loading ? 'Gerando...' : 'Gerar'}
           </button>
@@ -207,9 +207,9 @@ export default function ReplicatePage() {
                   key={job.id}
                   src={job.url!}
                   onClick={() => setSelectedImageUrl(job.url!)}
-                  className={`cursor-pointer rounded-md border-2 object-cover w-24 h-24 ${
+                  className={`cursor-pointer rounded-md border-2 object-cover w-24 h-24 transition-all transform hover:scale-105 ${
                     selectedImageUrl === job.url ? 'border-purple-500' : 'border-transparent'
-                  } hover:border-purple-400 transition`}
+                  } hover:border-purple-400`}
                   alt=""
                 />
               ))}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -44,7 +44,7 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 px-4 py-8">
-      <div className="w-full max-w-md p-8 rounded-xl bg-gray-800/80 backdrop-blur-md shadow-2xl">
+      <div className="w-full max-w-md p-8 rounded-xl bg-gray-800/80 backdrop-blur-md shadow-2xl animate-fade-in transform transition-all duration-300 hover:scale-[1.02]">
         <h1 className="text-2xl font-bold text-center text-white mb-6">Entrar</h1>
 
         {error && <p className="text-red-400 mb-4 text-center">{error}</p>}
@@ -62,7 +62,7 @@ export default function LoginPage() {
               value={email}
               onChange={e => setEmail(e.target.value)}
               placeholder="Email"
-              className="w-full pl-10 pr-4 py-2 rounded-md bg-gray-700/60 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full pl-10 pr-4 py-2 rounded-md bg-gray-700/60 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors hover:bg-gray-700"
               required
             />
           </div>
@@ -78,7 +78,7 @@ export default function LoginPage() {
               value={password}
               onChange={e => setPassword(e.target.value)}
               placeholder="Senha"
-              className="w-full pl-10 pr-10 py-2 rounded-md bg-gray-700/60 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              className="w-full pl-10 pr-10 py-2 rounded-md bg-gray-700/60 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors hover:bg-gray-700"
               required
             />
             <button
@@ -86,14 +86,14 @@ export default function LoginPage() {
               aria-label={showPassword ? 'Esconder senha' : 'Mostrar senha'}
               aria-pressed={showPassword}
               onClick={() => setShowPassword(s => !s)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 transition-transform transform hover:scale-110"
             >
               {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
             </button>
           </div>
           <button
             type="submit"
-            className="w-full py-2 rounded-md bg-purple-600 hover:bg-purple-700 text-white font-semibold transition-colors"
+            className="w-full py-2 rounded-md bg-purple-600 text-white font-semibold transition-all duration-300 transform hover:bg-purple-700 hover:scale-105"
           >
             Entrar
           </button>
@@ -101,7 +101,7 @@ export default function LoginPage() {
 
         <button
           onClick={handleGoogleLogin}
-          className="mt-4 w-full py-2 rounded-md bg-red-600 hover:bg-red-700 text-white font-semibold transition-colors"
+          className="mt-4 w-full py-2 rounded-md bg-red-600 text-white font-semibold transition-all duration-300 transform hover:bg-red-700 hover:scale-105"
         >
           Entrar com Google
         </button>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -28,8 +28,8 @@ export default function RegisterPage() {
 };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-900 px-4 py-8">
-      <div className="bg-gray-800 p-8 rounded-xl shadow-lg w-full max-w-md">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 px-4 py-8">
+      <div className="bg-gray-800/80 backdrop-blur-md p-8 rounded-xl shadow-2xl w-full max-w-md animate-fade-in transform transition-all duration-300 hover:scale-[1.02]">
         <h1 className="text-2xl font-bold text-center text-white mb-6">
           Registrar-se
         </h1>
@@ -42,7 +42,7 @@ export default function RegisterPage() {
             value={email}
             onChange={e => setEmail(e.target.value)}
             placeholder="Email"
-            className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400 focus:outline-none"
+            className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors hover:bg-gray-600"
             required
           />
           <input
@@ -50,12 +50,12 @@ export default function RegisterPage() {
             value={password}
             onChange={e => setPassword(e.target.value)}
             placeholder="Senha"
-            className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400 focus:outline-none"
+            className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 transition-colors hover:bg-gray-600"
             required
           />
           <button
             type="submit"
-            className="w-full py-2 rounded-md bg-purple-600 hover:bg-purple-700 text-white font-semibold"
+            className="w-full py-2 rounded-md bg-purple-600 text-white font-semibold transition-all duration-300 transform hover:bg-purple-700 hover:scale-105"
           >
             Registrar
           </button>

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -13,7 +13,7 @@ export default function ImageCard({ src, loading, onClick }: Props) {
 
   return (
     <div
-      className="relative inline-block max-w-full max-h-[80vh] rounded-xl overflow-hidden shadow-lg border border-gray-800 cursor-pointer group transform transition-transform duration-200 hover:scale-105"
+      className="relative inline-block max-w-full max-h-[80vh] rounded-xl overflow-hidden shadow-lg border border-gray-800 cursor-pointer group transform transition-all duration-300 hover:scale-105 animate-fade-in"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onClick={onClick}


### PR DESCRIPTION
## Summary
- add global fade-in animation utility
- animate login and register forms with hover scaling buttons
- polish Replicate page with gradient background and interactive controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb0835e58832f832b05ce1c5126e6