### PR TITLE
Atualiza histórico ao gerar imagens

### DIFF
--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -3,13 +3,12 @@
 import ImageCard from '../../../components/ImageCard';
 import ImageCardModal from '../../../components/ImageCardModal';
 import { useEffect, useState } from 'react';
-import { createReplicateJob, getJobStatus } from '../../../lib/api';
+import { createReplicateJob, getJobStatus, getUserHistory } from '../../../lib/api';
 import type { UiJob } from '../../../types/image-job';
 import { useAuth } from '../../../context/AuthContext';
 import { useImageHistory } from '../../../hooks/useImageHistory';
 import { mapApiToUiJob } from '../../../lib/api';
-import type { ImageJobApi } from '../../../types/image-job';
-import { normalizeUrl } from '../../../lib/api'; 
+import { normalizeUrl } from '../../../lib/api';
 
 
 
@@ -26,7 +25,7 @@ export default function ReplicatePage() {
   const [modalPrompt, setModalPrompt] = useState('');
   const [modalImage, setModalImage] = useState('');
   const { token } = useAuth();
-  const { history, setHistory, loading: historyLoading } = useImageHistory();
+  const { history, setHistory } = useImageHistory();
 
 
   
@@ -88,21 +87,8 @@ export default function ReplicatePage() {
         );
         setSelectedImageUrl(fullUrl);
 
-        setHistory((prev: ImageJobApi[]) => [
-          {
-            id: jobId,
-            jobId,
-            prompt,
-            userId: 'me',
-            status: 'done',
-            imageUrl: rawUrl, // mantém como veio (sem normalizar) — o map normaliza
-            imageUrls: content.imageUrls ?? (rawUrl ? [rawUrl] : []),
-            aspectRatio: selectedAspectRatio,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          },
-          ...prev,
-        ]);
+        const updatedHistory = await getUserHistory(token);
+        setHistory(updatedHistory);
 
         setLoading(false);
       }

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState } from 'react';
-import { Download } from 'lucide-react';
+import { Download, Loader2 } from 'lucide-react';
 
 type Props = {
   src?: string;
@@ -25,8 +25,8 @@ export default function ImageCard({ src, loading, onClick }: Props) {
 
       {/* Placeholder de carregamento */}
       {loading && (
-        <div className="flex items-center justify-center w-72 h-72 text-sm text-muted-foreground">
-          Gerando imagem...
+        <div className="flex items-center justify-center w-72 h-72 text-muted-foreground">
+          <Loader2 className="h-8 w-8 animate-spin" />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- atualiza o histórico ao finalizar a geração de imagens no fluxo Replicate
- usa ícone `Loader2` com animação para indicar carregamento de imagem

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb7cf3994832f8c08e3f8b81214ba