### PR TITLE
Use presigned URL for image downloads

### DIFF
--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -67,6 +67,7 @@ export default function ReplicatePage() {
       status: 'loading',
       url: null,
       aspectRatio: selectedAspectRatio,
+      prompt,
     };
 
     setImages((prev: UiJob[]) => [newJob, ...prev]);
@@ -107,6 +108,7 @@ export default function ReplicatePage() {
 
   // escolhe a imagem a ser exibida no centro
   const centerImageUrl = selectedImageUrl;
+  const centerPrompt = images.find(j => j.id === selectedJobId)?.prompt ?? '';
 
   return (
     <div className="flex h-full flex-1 flex-col lg:flex-row animate-fade-in">
@@ -171,6 +173,7 @@ export default function ReplicatePage() {
         {centerImageUrl ? (
           <ImageCard
             src={centerImageUrl}
+            prompt={centerPrompt}
             loading={false}
             onClick={() => {
               setModalOpen(true);

--- a/src/app/images/runpod/page.tsx
+++ b/src/app/images/runpod/page.tsx
@@ -109,6 +109,7 @@ const handleSubmit = async () => {
                 <ImageCard
                   key={`${job.id}-${i}`}
                   src={url}
+                  prompt={job.prompt}
                   loading={false}
                   onClick={() => {
                     setModalJobId(job.id);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,6 +51,7 @@ export default function Home() {
               <div key={job.id} className="mb-4 break-inside-avoid">
                 <ImageCard
                   src={job.imageUrl}
+                  prompt={job.prompt}
                   onClick={() => {
                     setSelected({ id: job.id, url: job.imageUrl });
                     setModalOpen(true);

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,15 +1,29 @@
 'use client';
 import { useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
+import { getPresignedDownloadUrl } from '../lib/api';
 
 type Props = {
   src?: string;
+  prompt?: string;
   loading?: boolean;
   onClick: () => void;
 };
 
-export default function ImageCard({ src, loading, onClick }: Props) {
+export default function ImageCard({ src, prompt = '', loading, onClick }: Props) {
   const [hovered, setHovered] = useState(false);
+
+  const handleDownload = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!src) return;
+    try {
+      const key = new URL(src).pathname.slice(1);
+      const url = await getPresignedDownloadUrl(key, prompt);
+      window.location.href = url;
+    } catch (err) {
+      console.error('Erro ao baixar imagem', err);
+    }
+  };
 
   return (
     <div
@@ -32,16 +46,12 @@ export default function ImageCard({ src, loading, onClick }: Props) {
 
       {/* Botão de download */}
       {hovered && src && !loading && (
-        <a
-          href={src}
-          download={`imagem-${Date.now()}.png`}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={e => e.stopPropagation()}
+        <button
+          onClick={handleDownload}
           className="absolute top-2 right-2 z-10 bg-black/60 p-2 rounded-full text-white hover:bg-black/80 transition"
         >
           <Download size={18} />
-        </a>
+        </button>
       )}
     </div>
   );

--- a/src/components/ImageCardModal.tsx
+++ b/src/components/ImageCardModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { X, Share2, Download } from 'lucide-react';
-import { getJobDetails } from '../lib/api';
+import { getJobDetails, getPresignedDownloadUrl } from '../lib/api';
 import { useAuth } from '../context/AuthContext';
 import type { JobDetails } from '../types/image-job';
 
@@ -47,6 +47,16 @@ export default function ImageCardModal({ isOpen, onClose, jobId, fallbackUrl }: 
   const imageUrl = details?.imageUrl ?? fallbackUrl;
   if (!imageUrl) return null;
 
+  const handleDownload = async () => {
+    try {
+      const key = new URL(imageUrl).pathname.slice(1);
+      const url = await getPresignedDownloadUrl(key, details?.prompt ?? '');
+      window.location.href = url;
+    } catch (err) {
+      console.error('Erro ao baixar imagem', err);
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
@@ -77,13 +87,12 @@ export default function ImageCardModal({ isOpen, onClose, jobId, fallbackUrl }: 
             <button className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700" disabled={!details}>
               <Share2 size={14} /> Share
             </button>
-            <a
+            <button
               className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700"
-              href={imageUrl}
-              download
+              onClick={handleDownload}
             >
               <Download size={14} /> Download
-            </a>
+            </button>
           </div>
 
           <div className="text-sm space-y-1">

--- a/src/hooks/useImageJobs.ts
+++ b/src/hooks/useImageJobs.ts
@@ -9,6 +9,7 @@ export interface ImageJob {
   status: 'loading' | 'done';
   urls: string[] | null;
   resolution: { width: number; height: number };
+  prompt?: string;
 }
 
 export function useImageJobs() {
@@ -55,7 +56,7 @@ export function useImageJobs() {
   // Criar um novo job e inserir placeholder
   const submitPrompt = async (prompt: string, resolution: { width: number; height: number }) => {
     const jobId = await createRunpodJob(prompt, resolution);
-    const placeholder: ImageJob = { id: jobId, status: 'loading', urls: null, resolution };
+    const placeholder: ImageJob = { id: jobId, status: 'loading', urls: null, resolution, prompt };
     setJobs(prev => [placeholder, ...prev]);
     return jobId;
   };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -44,6 +44,15 @@ export async function getJobDetails(jobId: string): Promise<JobDetails> {
   };
 }
 
+export async function getPresignedDownloadUrl(key: string, prompt: string): Promise<string> {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/download/${encodeURIComponent(key)}?prompt=${encodeURIComponent(prompt)}`,
+  );
+  if (!res.ok) throw new Error('Erro ao gerar URL de download');
+  const json = await res.json();
+  return String(json.url ?? json.presignedUrl ?? '');
+}
+
 export async function getLatestJobs(): Promise<LatestJob[]> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/jobs/latest`);
   if (!res.ok) throw new Error('Erro ao carregar jobs');
@@ -130,6 +139,7 @@ export function mapApiToUiJob(j: ImageJobApi): UiJob {
     status: j.status?.toUpperCase() === 'COMPLETED' ? 'done' : 'loading',
     url: normalizeUrl(rawUrl),                               // <<<<<< normaliza
     aspectRatio: j.aspectRatio ?? '1:1',
+    prompt: j.prompt ?? '',
   };
 }
 

--- a/src/types/image-job.ts
+++ b/src/types/image-job.ts
@@ -18,6 +18,7 @@ export interface UiJob {
   status: 'loading' | 'done';
   url: string | null;
   aspectRatio: string;
+  prompt?: string;
 }
 
 // Detalhes retornados pelo endpoint GET /api/jobs/details/{jobId}


### PR DESCRIPTION
## Summary
- replace direct image anchor downloads with API-driven presigned URL redirects
- attach prompt to download requests and plumb prompt through job state
- add helper API for presigned URLs and update types accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4de883e68832f868e936de9bc657c