### PR TITLE
Fetch pre-signed URL before downloading images

### DIFF
--- a/src/app/images/replicate/page.tsx
+++ b/src/app/images/replicate/page.tsx
@@ -171,6 +171,7 @@ export default function ReplicatePage() {
         {centerImageUrl ? (
           <ImageCard
             src={centerImageUrl}
+            prompt={prompt}
             loading={false}
             onClick={() => {
               setModalOpen(true);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,6 +51,7 @@ export default function Home() {
               <div key={job.id} className="mb-4 break-inside-avoid">
                 <ImageCard
                   src={job.imageUrl}
+                  prompt={job.prompt}
                   onClick={() => {
                     setSelected({ id: job.id, url: job.imageUrl });
                     setModalOpen(true);

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
+import { handleDownload } from '../lib/download';
 
 type Props = {
   src?: string;
+  prompt?: string;
   loading?: boolean;
   onClick: () => void;
 };
 
-export default function ImageCard({ src, loading, onClick }: Props) {
+export default function ImageCard({ src, prompt, loading, onClick }: Props) {
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -31,17 +33,15 @@ export default function ImageCard({ src, loading, onClick }: Props) {
       )}
 
       {/* Botão de download */}
-      {hovered && src && !loading && (
-        <a
-          href={src}
-          download={`imagem-${Date.now()}.png`}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={e => e.stopPropagation()}
+      {hovered && src && prompt && !loading && (
+        <button
+          onClick={e => handleDownload(e, src, prompt)}
           className="absolute top-2 right-2 z-10 bg-black/60 p-2 rounded-full text-white hover:bg-black/80 transition"
+          aria-label="Baixar imagem"
+          title="Baixar imagem"
         >
           <Download size={18} />
-        </a>
+        </button>
       )}
     </div>
   );

--- a/src/components/ImageCardModal.tsx
+++ b/src/components/ImageCardModal.tsx
@@ -5,6 +5,7 @@ import { X, Share2, Download } from 'lucide-react';
 import { getJobDetails } from '../lib/api';
 import { useAuth } from '../context/AuthContext';
 import type { JobDetails } from '../types/image-job';
+import { handleDownload } from '../lib/download';
 
 type Props = {
   isOpen: boolean;
@@ -77,13 +78,13 @@ export default function ImageCardModal({ isOpen, onClose, jobId, fallbackUrl }: 
             <button className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700" disabled={!details}>
               <Share2 size={14} /> Share
             </button>
-            <a
+            <button
               className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700"
-              href={imageUrl}
-              download
+              onClick={e => details && handleDownload(e, imageUrl, details.prompt)}
+              disabled={!details}
             >
               <Download size={14} /> Download
-            </a>
+            </button>
           </div>
 
           <div className="text-sm space-y-1">

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,0 +1,21 @@
+import type { MouseEvent } from 'react';
+
+const R2_PUBLIC_BASE = process.env.NEXT_PUBLIC_R2_PUBLIC_BASE!;
+
+export function extractKeyFromSrc(src: string) {
+  try {
+    const u = new URL(src);
+    return u.pathname.replace(/^\//, '');
+  } catch {
+    return src.replace(`${R2_PUBLIC_BASE}/`, '');
+  }
+}
+
+export async function handleDownload(e: MouseEvent, src: string, prompt: string) {
+  e.stopPropagation();
+  const key = extractKeyFromSrc(src);
+  const params = new URLSearchParams({ key, prompt });
+  const res = await fetch(`/api/files/download-url?${params.toString()}`);
+  const data = await res.json();
+  window.location.href = data.url;
+}


### PR DESCRIPTION
## Summary
- Replace direct download links with buttons that fetch a pre-signed URL
- Add helper to extract R2 key and fetch download URL
- Pass original prompt to download handler for naming

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68a525261380832fa2f38845e5c811c0