### PR TITLE
feat: enable image download prompt

### DIFF
--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
+import { downloadImage } from '@/lib/download';
 
 type Props = {
   src?: string;
@@ -32,16 +33,16 @@ export default function ImageCard({ src, loading, onClick }: Props) {
 
       {/* Botão de download */}
       {hovered && src && !loading && (
-        <a
-          href={src}
-          download={`imagem-${Date.now()}.png`}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={e => e.stopPropagation()}
+        <button
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            void downloadImage(src, `imagem-${Date.now()}.png`);
+          }}
           className="absolute top-2 right-2 z-10 bg-black/60 p-2 rounded-full text-white hover:bg-black/80 transition"
         >
           <Download size={18} />
-        </a>
+        </button>
       )}
     </div>
   );

--- a/src/components/ImageCardModal.tsx
+++ b/src/components/ImageCardModal.tsx
@@ -5,6 +5,7 @@ import { X, Share2, Download } from 'lucide-react';
 import { getJobDetails } from '../lib/api';
 import { useAuth } from '../context/AuthContext';
 import type { JobDetails } from '../types/image-job';
+import { downloadImage } from '@/lib/download';
 
 type Props = {
   isOpen: boolean;
@@ -77,13 +78,13 @@ export default function ImageCardModal({ isOpen, onClose, jobId, fallbackUrl }: 
             <button className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700" disabled={!details}>
               <Share2 size={14} /> Share
             </button>
-            <a
+            <button
+              type="button"
               className="flex items-center gap-1 text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700"
-              href={imageUrl}
-              download
+              onClick={() => downloadImage(imageUrl, `imagem-${Date.now()}.png`)}
             >
               <Download size={14} /> Download
-            </a>
+            </button>
           </div>
 
           <div className="text-sm space-y-1">

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,0 +1,12 @@
+export async function downloadImage(url: string, filename: string) {
+  const res = await fetch(url);
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}


### PR DESCRIPTION
## Summary
- add download utility to trigger browser download
- use button in image card and modal to download directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a52cbbac84832fae16e0d0453cc9c5