### PR TITLE
Integrate Stripe billing pages and add pricing navigation

### DIFF
--- a/src/app/checkout/cancel/page.tsx
+++ b/src/app/checkout/cancel/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function CheckoutCancelPage() {
+  return (
+    <div className="min-h-screen mt-24 px-4 py-10 bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900 text-gray-100 flex flex-col items-center">
+      <h1 className="text-2xl font-bold mb-4">Pagamento cancelado ou não concluído. Tente novamente.</h1>
+      <Link href="/pricing" className="text-purple-400 hover:underline">
+        Voltar para planos
+      </Link>
+    </div>
+  );
+}
+

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { getBillingMe, type BillingMe } from '../../../lib/billing';
+
+export default function CheckoutSuccessPage() {
+  const params = useSearchParams();
+  const _sessionId = params.get('session_id');
+  const [info, setInfo] = useState<BillingMe | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getBillingMe();
+        setInfo(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="min-h-screen mt-24 px-4 py-10 bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900 text-gray-100 flex flex-col items-center">
+      <h1 className="text-2xl font-bold mb-4">Pagamento concluído!</h1>
+      {info ? (
+        <p className="mb-4 text-center">
+          Plano: <span className="font-semibold text-purple-400">{info.plan}</span>
+          <br />
+          Status: {info.subscriptionStatus || '--'}
+          <br />
+          Próxima renovação:{' '}
+          {info.currentPeriodEnd ? new Date(info.currentPeriodEnd).toLocaleDateString() : '--'}
+        </p>
+      ) : (
+        <p className="mb-4">Carregando...</p>
+      )}
+      <Link href="/profile" className="text-purple-400 hover:underline">
+        Ir para o perfil
+      </Link>
+    </div>
+  );
+}
+

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import { createCheckoutSession } from '../../lib/billing';
+
+export default function PricingPage() {
+  const [loading, setLoading] = useState<'PRO' | 'ULTRA' | null>(null);
+
+  const handleSubscribe = async (plan: 'PRO' | 'ULTRA') => {
+    try {
+      setLoading(plan);
+      const { url } = await createCheckoutSession(plan);
+      window.location.href = url;
+    } catch (err) {
+      console.error(err);
+      setLoading(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen mt-24 px-4 py-10 bg-gradient-to-br from-gray-900 via-gray-800 to-purple-900 text-gray-100 flex items-center justify-center">
+      <div className="flex space-x-8">
+        <div className="bg-gray-900/40 p-6 rounded-xl w-64 text-center">
+          <h2 className="text-xl font-bold mb-2">PRO</h2>
+          <p className="mb-4">US$10 / mês</p>
+          <button
+            className="bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700 disabled:opacity-50"
+            onClick={() => handleSubscribe('PRO')}
+            disabled={loading !== null}
+          >
+            {loading === 'PRO' ? 'Carregando...' : 'Assinar PRO'}
+          </button>
+        </div>
+        <div className="bg-gray-900/40 p-6 rounded-xl w-64 text-center">
+          <h2 className="text-xl font-bold mb-2">ULTRA</h2>
+          <p className="mb-4">US$20 / mês</p>
+          <button
+            className="bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700 disabled:opacity-50"
+            onClick={() => handleSubscribe('ULTRA')}
+            disabled={loading !== null}
+          >
+            {loading === 'ULTRA' ? 'Carregando...' : 'Assinar ULTRA'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -75,6 +75,7 @@ export default function Navbar() {
             <Link href="/images/replicate" className="hover:text-purple-400 transition">Images</Link>
             <Link href="/voices" className="hover:text-purple-400 transition">Voice</Link>
             <Link href="/videos" className="hover:text-purple-400 transition">Video</Link>
+            <Link href="/pricing" className="hover:text-purple-400 transition">Planos</Link>
           </nav>
         </div>
 

--- a/src/components/profile/Billing.tsx
+++ b/src/components/profile/Billing.tsx
@@ -1,10 +1,37 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { getBillingMe, createPortalSession, type BillingMe } from '../../lib/billing';
 
 export default function Billing() {
   const [visible, setVisible] = useState(false);
-  useEffect(() => setVisible(true), []);
+  const [info, setInfo] = useState<BillingMe | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setVisible(true);
+    async function load() {
+      try {
+        const data = await getBillingMe();
+        setInfo(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const handleManage = async () => {
+    try {
+      const { url } = await createPortalSession();
+      window.location.href = url;
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
     <div
@@ -12,33 +39,38 @@ export default function Billing() {
         visible ? 'opacity-100' : 'opacity-0'
       } transition-opacity duration-300 space-y-6`}
     >
-      <section>
-        <h2 className="text-xl font-semibold mb-2">Current Plan</h2>
-        <p className="text-sm text-gray-300">
-          You are on the{' '}
-          <span className="text-purple-400 font-medium">Free</span> plan.
-        </p>
-      </section>
-
-      <section>
-        <h3 className="text-lg font-semibold mb-2">Payment History</h3>
-        <table className="w-full text-left text-sm bg-gray-900/40 rounded-lg overflow-hidden">
-          <thead>
-            <tr className="text-gray-400">
-              <th className="py-2">Date</th>
-              <th className="py-2">Plan</th>
-              <th className="py-2">Amount</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="border-t border-gray-700">
-              <td className="py-2">01/01/2024</td>
-              <td className="py-2">Pro</td>
-              <td className="py-2">R$49</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
+      {loading ? (
+        <p className="text-sm text-gray-300">Carregando...</p>
+      ) : !info?.plan ? (
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Você está no plano Free</h2>
+          <Link href="/pricing" className="text-purple-400 hover:underline">
+            Ver Planos
+          </Link>
+        </section>
+      ) : (
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-xl font-semibold mb-2">
+              Plano atual: {info.plan}
+            </h2>
+            <p className="text-sm text-gray-300">
+              Status: {info.subscriptionStatus ?? '--'}
+              <br />
+              Renovação:{' '}
+              {info.currentPeriodEnd
+                ? new Date(info.currentPeriodEnd).toLocaleDateString()
+                : '--'}
+            </p>
+          </div>
+          <button
+            onClick={handleManage}
+            className="bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700"
+          >
+            Gerenciar assinatura
+          </button>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,34 @@
+import { fetchWithAuth } from '../lib/auth';
+
+export interface BillingMe {
+  plan?: 'PRO' | 'ULTRA' | null;
+  subscriptionStatus?: string | null;
+  currentPeriodEnd?: string | null; // ISO
+}
+
+export async function getBillingMe(): Promise<BillingMe> {
+  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/billing/me`, { credentials: 'include' });
+  if (!res.ok) throw new Error('Erro ao obter assinatura');
+  return res.json();
+}
+
+export async function createCheckoutSession(plan: 'PRO' | 'ULTRA'): Promise<{ url: string }> {
+  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/billing/checkout`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plan }),
+  });
+  if (!res.ok) throw new Error('Erro ao criar sessão de checkout');
+  return res.json();
+}
+
+export async function createPortalSession(): Promise<{ url: string }> {
+  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/billing/portal`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Erro ao criar sessão do portal');
+  return res.json();
+}
+

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -7,13 +7,14 @@ export interface BillingMe {
 }
 
 export async function getBillingMe(): Promise<BillingMe> {
-  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/billing/me`, { credentials: 'include' });
+  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/api/billing/me`, { credentials: 'include' });
   if (!res.ok) throw new Error('Erro ao obter assinatura');
   return res.json();
 }
 
 export async function createCheckoutSession(plan: 'PRO' | 'ULTRA'): Promise<{ url: string }> {
-  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/billing/checkout`, {
+  debugger
+  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/api/billing/checkout`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
@@ -24,7 +25,7 @@ export async function createCheckoutSession(plan: 'PRO' | 'ULTRA'): Promise<{ ur
 }
 
 export async function createPortalSession(): Promise<{ url: string }> {
-  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/billing/portal`, {
+  const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/api/billing/portal`, {
     method: 'POST',
     credentials: 'include',
   });


### PR DESCRIPTION
## Summary
- add billing API helpers for checkout, portal, and current subscription
- build pricing and checkout result pages with Stripe session redirects
- update profile billing tab and navbar with plan links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda13d01e8832fadd75ea3fca7a0d1