### PR TITLE
feat: add email verification and password reset ux

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { forgotPassword } from '../../lib/api';
+import Link from 'next/link';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await forgotPassword(email);
+    } finally {
+      setSent(true);
+      setLoading(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white">
+        <div className="text-center space-y-4">
+          <p>Se um usuário existir, enviamos um email com instruções.</p>
+          <Link href="/login" className="text-purple-400 underline">
+            Voltar ao login
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 px-4 py-8">
+      <form onSubmit={handleSubmit} className="bg-gray-800/80 p-8 rounded-xl shadow-2xl w-full max-w-md text-white space-y-4">
+        <h1 className="text-2xl font-bold text-center mb-4">Esqueci minha senha</h1>
+        <input
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          placeholder="Email"
+          className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400"
+          required
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 rounded-md bg-purple-600 font-semibold disabled:opacity-50"
+        >
+          {loading ? 'Enviando…' : 'Enviar'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,12 +6,14 @@ import Link from 'next/link';
 import { loginUser } from '../../lib/api';
 import { AuthContext } from '../../context/AuthContext';
 import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import ResendVerificationModal from '../../components/ResendVerificationModal';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [showVerifyModal, setShowVerifyModal] = useState(false);
   const router = useRouter();
   const auth = useContext(AuthContext);
 
@@ -23,7 +25,11 @@ export default function LoginPage() {
       auth.login(token);
       router.push('/images/replicate');
     } catch (err: unknown) {
-      setError('Failed to log in');
+      if (err instanceof Error && err.message === 'EMAIL_NOT_VERIFIED') {
+        setShowVerifyModal(true);
+      } else {
+        setError('Failed to log in');
+      }
     }
   };
 
@@ -106,6 +112,12 @@ export default function LoginPage() {
           Log in with Google
         </button>
 
+        <p className="mt-4 text-center">
+          <Link href="/forgot-password" className="text-purple-400 hover:underline">
+            Forgot password?
+          </Link>
+        </p>
+
         <p className="mt-4 text-center text-gray-400">
           Don&apos;t have an account?{' '}
           <Link href="/register" className="text-purple-400 hover:underline">
@@ -113,6 +125,13 @@ export default function LoginPage() {
           </Link>
         </p>
       </div>
+      {showVerifyModal && (
+        <ResendVerificationModal
+          email={email}
+          open={showVerifyModal}
+          onClose={() => setShowVerifyModal(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/register/confirm-email-sent.tsx
+++ b/src/app/register/confirm-email-sent.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { resendVerification } from '../../lib/api';
+
+export default function ConfirmEmailSentPage({ email }: { email: string }) {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
+
+  async function handleResend() {
+    setStatus('sending');
+    try {
+      await resendVerification(email);
+      setStatus('sent');
+    } finally {
+      setStatus('sent');
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 px-4 py-8">
+      <div className="bg-gray-800/80 backdrop-blur-md p-8 rounded-xl shadow-2xl w-full max-w-md text-center">
+        <h1 className="text-2xl font-bold text-white mb-4">Confirme seu e-mail</h1>
+        <p className="text-gray-300 mb-4">
+          Enviamos um link de verificação para {email}.
+        </p>
+        {status === 'sent' && (
+          <p className="text-green-500 mb-2" aria-live="polite">
+            Email reenviado!
+          </p>
+        )}
+        <button
+          onClick={handleResend}
+          disabled={status === 'sending'}
+          className="w-full py-2 rounded-md bg-purple-600 text-white font-semibold transition-all duration-300 transform hover:bg-purple-700 disabled:opacity-50"
+        >
+          {status === 'sending' ? 'Enviando…' : 'Reenviar verificação'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { registerUser } from '../../lib/api';
+import ConfirmEmailSentPage from './confirm-email-sent';
 import { useContext } from 'react';
 import { AuthContext } from '../../context/AuthContext';
 
@@ -12,20 +12,27 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
-  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
   const auth = useContext(AuthContext);
 
   const handleSubmit = async (e: React.FormEvent) => {
-  e.preventDefault();
-  if (!auth) return;
-  try {
-    const { token } = await registerUser(email, password);
-    auth.login(token);
-    router.push('/images/replicate');
-  } catch (err: unknown) {
-    setError('Failed to register');
+    e.preventDefault();
+    if (!auth) return;
+    setLoading(true);
+    try {
+      await registerUser(email, password);
+      setSuccess(true);
+    } catch {
+      setError('Failed to register');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return <ConfirmEmailSentPage email={email} />;
   }
-};
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 px-4 py-8">
@@ -55,9 +62,10 @@ export default function RegisterPage() {
           />
           <button
             type="submit"
-            className="w-full py-2 rounded-md bg-purple-600 text-white font-semibold transition-all duration-300 transform hover:bg-purple-700 hover:scale-105"
+            className="w-full py-2 rounded-md bg-purple-600 text-white font-semibold transition-all duration-300 transform hover:bg-purple-700 hover:scale-105 disabled:opacity-50"
+            disabled={loading}
           >
-            Register
+            {loading ? 'Enviando…' : 'Register'}
           </button>
         </form>
 

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { resetPassword } from '../../lib/api';
+
+export default function ResetPasswordPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const token = params.get('token') || '';
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+  const [status, setStatus] = useState<'form' | 'success'>('form');
+  const [loading, setLoading] = useState(false);
+
+  const messages: Record<string, string> = {
+    TOKEN_INVALID: 'Link inválido.',
+    TOKEN_EXPIRED: 'Link expirado. Peça um novo link.',
+    TOKEN_CONSUMED: 'Este link já foi usado.',
+    WEAK_PASSWORD: 'Senha fraca. Use 8+ caracteres com número e símbolo.',
+  };
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (password !== confirm) {
+      setError('As senhas não conferem');
+      return;
+    }
+    setLoading(true);
+    try {
+      await resetPassword(token, password);
+      setStatus('success');
+    } catch (err: unknown) {
+      const code = (err as Error).message;
+      setError(messages[code] || 'Erro ao redefinir senha');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white flex-col gap-4">
+        <p>Senha redefinida com sucesso.</p>
+        <button
+          onClick={() => router.push('/login')}
+          className="px-4 py-2 bg-purple-600 rounded-md"
+        >
+          Ir para login
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-purple-900 to-gray-950 px-4 py-8">
+      <form onSubmit={handleSubmit} className="bg-gray-800/80 p-8 rounded-xl shadow-2xl w-full max-w-md text-white space-y-4">
+        <h1 className="text-2xl font-bold text-center mb-4">Redefinir senha</h1>
+        {error && (
+          <p className="text-red-500" aria-live="polite">
+            {error}
+          </p>
+        )}
+        <input
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          placeholder="Nova senha"
+          className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400"
+          required
+        />
+        <input
+          type="password"
+          value={confirm}
+          onChange={e => setConfirm(e.target.value)}
+          placeholder="Confirmar senha"
+          className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400"
+          required
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 rounded-md bg-purple-600 font-semibold disabled:opacity-50"
+        >
+          {loading ? 'Enviando…' : 'Redefinir'}
+        </button>
+        <Link href="/login" className="block text-purple-400 underline text-center">
+          Voltar para login
+        </Link>
+      </form>
+    </div>
+  );
+}

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { verifyEmail, resendVerification } from '../../lib/api';
+
+export default function VerifyEmailPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const token = params.get('token') || '';
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [email, setEmail] = useState('');
+  const [resendStatus, setResendStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
+
+  useEffect(() => {
+    async function run() {
+      try {
+        await verifyEmail(token);
+        setStatus('success');
+      } catch (err: unknown) {
+        setErrorCode((err as Error).message);
+        setStatus('error');
+      }
+    }
+    if (token) run();
+  }, [token]);
+
+  async function handleResend() {
+    setResendStatus('sending');
+    try {
+      await resendVerification(email);
+      setResendStatus('sent');
+    } finally {
+      setResendStatus('sent');
+    }
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white">Verificando…</div>
+    );
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white flex-col gap-4">
+        <p>Email verificado com sucesso!</p>
+        <button
+          onClick={() => router.push('/login')}
+          className="px-4 py-2 bg-purple-600 rounded-md"
+        >
+          Ir para login
+        </button>
+      </div>
+    );
+  }
+
+  const messages: Record<string, string> = {
+    TOKEN_INVALID: 'Link inválido.',
+    TOKEN_EXPIRED: 'Link expirado. Clique em Reenviar.',
+    TOKEN_CONSUMED: 'Este link já foi usado.',
+  };
+  const msg = messages[errorCode || 'TOKEN_INVALID'];
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 py-8">
+      <div className="bg-gray-800/80 backdrop-blur-md p-8 rounded-xl shadow-2xl w-full max-w-md text-center text-white">
+        <p className="mb-4">{msg}</p>
+        {resendStatus === 'sent' ? (
+          <p className="text-green-500 mb-4" aria-live="polite">
+            Email reenviado!
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              placeholder="Seu email"
+              className="w-full px-4 py-2 rounded-md bg-gray-700 text-white placeholder-gray-400"
+            />
+            <button
+              onClick={handleResend}
+              disabled={resendStatus === 'sending'}
+              className="w-full py-2 bg-purple-600 rounded-md disabled:opacity-50"
+            >
+              {resendStatus === 'sending' ? 'Enviando…' : 'Reenviar'}
+            </button>
+          </div>
+        )}
+        <Link href="/login" className="block mt-4 text-purple-400 underline">
+          Voltar para login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResendVerificationModal.tsx
+++ b/src/components/ResendVerificationModal.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { resendVerification } from '../lib/api';
+
+interface Props {
+  email: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function ResendVerificationModal({ email, open, onClose }: Props) {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
+
+  if (!open) return null;
+
+  async function handleResend() {
+    setStatus('sending');
+    try {
+      await resendVerification(email);
+      setStatus('sent');
+    } finally {
+      setStatus('sent');
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-white rounded-md p-6 w-full max-w-sm text-center">
+        <h2 className="text-lg font-semibold mb-2">Confirme seu e-mail</h2>
+        <p className="text-sm mb-4">Enviamos um link para {email}. Não recebeu?</p>
+        {status === 'sent' && (
+          <p className="text-green-600 mb-2" aria-live="polite">
+            Email reenviado!
+          </p>
+        )}
+        <div className="space-y-2">
+          <button
+            onClick={handleResend}
+            disabled={status === 'sending'}
+            className="w-full py-2 bg-purple-600 text-white rounded-md disabled:opacity-50"
+          >
+            {status === 'sending' ? 'Enviando…' : 'Reenviar'}
+          </button>
+          <button
+            onClick={onClose}
+            className="w-full py-2 bg-gray-200 rounded-md"
+          >
+            Fechar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -13,14 +13,20 @@ export async function getBillingMe(): Promise<BillingMe> {
 }
 
 export async function createCheckoutSession(plan: 'PRO' | 'ULTRA'): Promise<{ url: string }> {
-  debugger
   const res = await fetchWithAuth(`${process.env.NEXT_PUBLIC_API_URL}/api/billing/checkout`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ plan }),
   });
-  if (!res.ok) throw new Error('Erro ao criar sessão de checkout');
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    const code = data.code as string | undefined;
+    if (res.status === 403 && code) {
+      throw new Error(code);
+    }
+    throw new Error('Erro ao criar sessão de checkout');
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- add API helpers for verifying emails and resetting passwords
- implement verification, password reset, and forgot password pages
- show resend verification modal when backend signals EMAIL_NOT_VERIFIED

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf53514e20832f901d5f6a30d9fbaa