### PR TITLE
Adjust image preview sizing for tall outputs

### DIFF
--- a/src/app/images/MobileModelNav.tsx
+++ b/src/app/images/MobileModelNav.tsx
@@ -10,9 +10,11 @@ export default function MobileModelNav() {
   const pathname = usePathname();
   const [models, setModels] = useState<PublicImageModelSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showNewPing, setShowNewPing] = useState(true);
 
   useEffect(() => {
     let active = true;
+    const timer = window.setTimeout(() => setShowNewPing(false), 10000);
 
     async function loadModels() {
       try {
@@ -36,6 +38,7 @@ export default function MobileModelNav() {
 
     return () => {
       active = false;
+      window.clearTimeout(timer);
     };
   }, []);
 
@@ -93,7 +96,9 @@ export default function MobileModelNav() {
               </div>
               {isNewest && (
                 <span className="relative inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white">
-                  <span className="absolute inset-0 animate-ping rounded-full bg-fuchsia-400/40" aria-hidden />
+                  {showNewPing && (
+                    <span className="absolute inset-0 animate-ping rounded-full bg-fuchsia-400/40" aria-hidden />
+                  )}
                   <span className="relative">New</span>
                 </span>
               )}

--- a/src/app/images/MobileModelNav.tsx
+++ b/src/app/images/MobileModelNav.tsx
@@ -64,8 +64,9 @@ export default function MobileModelNav() {
       )}
 
       {!loading &&
-        models.map(model => {
+        models.map((model, index) => {
           const isActive = activeSlug === model.slug;
+          const isNewest = index === 0;
           return (
             <Link
               key={model.slug}
@@ -90,6 +91,12 @@ export default function MobileModelNav() {
                 <span className="truncate text-sm font-semibold">{model.displayName}</span>
                 <span className="text-[10px] uppercase tracking-[0.28em] text-gray-400">{model.slug.replace(/-/g, ' ')}</span>
               </div>
+              {isNewest && (
+                <span className="relative inline-flex items-center rounded-full border border-white/20 bg-white/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white">
+                  <span className="absolute inset-0 animate-ping rounded-full bg-fuchsia-400/40" aria-hidden />
+                  <span className="relative">New</span>
+                </span>
+              )}
             </Link>
           );
         })}

--- a/src/app/images/Sidebar.tsx
+++ b/src/app/images/Sidebar.tsx
@@ -79,7 +79,7 @@ export default function Sidebar() {
                   </div>
 
                   {isNewest && (
-                    <div className="pointer-events-none absolute right-4 top-3 -translate-y-1 flex items-center" aria-hidden>
+                    <div className="pointer-events-none absolute right-4 -top-2 flex items-center" aria-hidden>
                       <span className="relative inline-flex items-center gap-1 overflow-hidden rounded-full border border-white/20 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-cyan-400 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white shadow-lg shadow-fuchsia-500/40">
                         <span className="absolute inset-0 animate-ping rounded-full bg-white/30" />
                         <span className="relative">New</span>

--- a/src/app/images/Sidebar.tsx
+++ b/src/app/images/Sidebar.tsx
@@ -60,9 +60,10 @@ export default function Sidebar() {
       <nav className="space-y-3">
         {loading
           ? skeletonItems
-          : models.map(model => {
+          : models.map((model, index) => {
               const href = `/images/${model.slug}`;
               const active = pathname === href;
+              const isNewest = index === 0;
               return (
                 <Link
                   key={model.slug}
@@ -76,6 +77,15 @@ export default function Sidebar() {
                   <div className="pointer-events-none absolute -inset-1 -z-10 opacity-0 blur-2xl transition duration-300 group-hover:opacity-70" aria-hidden>
                     <div className="h-full w-full bg-gradient-to-r from-fuchsia-500/30 via-purple-500/20 to-cyan-400/25" />
                   </div>
+
+                  {isNewest && (
+                    <div className="pointer-events-none absolute right-4 top-4 flex items-center" aria-hidden>
+                      <span className="relative inline-flex items-center gap-1 overflow-hidden rounded-full border border-white/20 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-cyan-400 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white shadow-lg shadow-fuchsia-500/40">
+                        <span className="absolute inset-0 animate-ping rounded-full bg-white/30" />
+                        <span className="relative">New</span>
+                      </span>
+                    </div>
+                  )}
 
                   <div className="relative flex items-center gap-4">
                     <div

--- a/src/app/images/Sidebar.tsx
+++ b/src/app/images/Sidebar.tsx
@@ -68,7 +68,7 @@ export default function Sidebar() {
                 <Link
                   key={model.slug}
                   href={href}
-                  className={`group relative block overflow-hidden rounded-3xl border px-5 py-5 transition ${
+                  className={`group relative block overflow-visible rounded-3xl border px-5 py-5 transition ${
                     active
                       ? 'border-fuchsia-300/70 bg-gradient-to-br from-fuchsia-600/30 via-purple-500/25 to-cyan-400/25 shadow-xl shadow-purple-500/40'
                       : 'border-white/10 bg-gradient-to-br from-white/5 via-white/0 to-fuchsia-500/5 hover:border-fuchsia-300/50 hover:shadow-lg hover:shadow-fuchsia-500/20'
@@ -79,10 +79,10 @@ export default function Sidebar() {
                   </div>
 
                   {isNewest && (
-                    <div className="pointer-events-none absolute right-4 -top-2 flex items-center" aria-hidden>
-                      <span className="relative inline-flex items-center gap-1 overflow-hidden rounded-full border border-white/20 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-cyan-400 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white shadow-lg shadow-fuchsia-500/40">
-                        <span className="absolute inset-0 animate-ping rounded-full bg-white/30" />
-                        <span className="relative">New</span>
+                    <div className="pointer-events-none absolute -right-1 -top-4 flex items-center" aria-hidden>
+                      <span className="relative inline-flex items-center gap-1 rounded-full border border-white/30 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-cyan-400 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white shadow-[0_12px_22px_-6px_rgba(236,72,153,0.55)] drop-shadow-[0_6px_12px_rgba(0,0,0,0.45)]">
+                        <span className="absolute inset-0 animate-ping rounded-full bg-white/35" />
+                        <span className="relative -translate-y-[1px] -rotate-3">New</span>
                       </span>
                     </div>
                   )}

--- a/src/app/images/Sidebar.tsx
+++ b/src/app/images/Sidebar.tsx
@@ -10,9 +10,11 @@ export default function Sidebar() {
   const pathname = usePathname();
   const [models, setModels] = useState<PublicImageModelSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showNewPing, setShowNewPing] = useState(true);
 
   useEffect(() => {
     let active = true;
+    const timer = window.setTimeout(() => setShowNewPing(false), 10000);
 
     async function loadModels() {
       try {
@@ -33,6 +35,7 @@ export default function Sidebar() {
 
     return () => {
       active = false;
+      window.clearTimeout(timer);
     };
   }, []);
 
@@ -81,7 +84,7 @@ export default function Sidebar() {
                   {isNewest && (
                     <div className="pointer-events-none absolute -right-1 -top-4 flex items-center" aria-hidden>
                       <span className="relative inline-flex items-center gap-1 rounded-full border border-white/30 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-cyan-400 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white shadow-[0_12px_22px_-6px_rgba(236,72,153,0.55)] drop-shadow-[0_6px_12px_rgba(0,0,0,0.45)]">
-                        <span className="absolute inset-0 animate-ping rounded-full bg-white/35" />
+                        {showNewPing && <span className="absolute inset-0 animate-ping rounded-full bg-white/35" />}
                         <span className="relative -translate-y-[1px] -rotate-3">New</span>
                       </span>
                     </div>

--- a/src/app/images/Sidebar.tsx
+++ b/src/app/images/Sidebar.tsx
@@ -79,7 +79,7 @@ export default function Sidebar() {
                   </div>
 
                   {isNewest && (
-                    <div className="pointer-events-none absolute right-4 top-4 flex items-center" aria-hidden>
+                    <div className="pointer-events-none absolute right-4 top-3 -translate-y-1 flex items-center" aria-hidden>
                       <span className="relative inline-flex items-center gap-1 overflow-hidden rounded-full border border-white/20 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-cyan-400 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.25em] text-white shadow-lg shadow-fuchsia-500/40">
                         <span className="absolute inset-0 animate-ping rounded-full bg-white/30" />
                         <span className="relative">New</span>

--- a/src/components/ImageCard.tsx
+++ b/src/components/ImageCard.tsx
@@ -25,7 +25,7 @@ export default function ImageCard({ src, jobId, status = 'done', onClick }: Prop
 
   return (
     <div
-      className="group relative w-full cursor-pointer overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-xl shadow-purple-500/10 transition duration-300 hover:-translate-y-1 hover:border-fuchsia-400/40 hover:shadow-purple-500/30 animate-fade-in"
+      className="group relative flex w-full cursor-pointer overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-xl shadow-purple-500/10 transition duration-300 hover:-translate-y-1 hover:border-fuchsia-400/40 hover:shadow-purple-500/30 animate-fade-in"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onClick={onClick}
@@ -42,7 +42,7 @@ export default function ImageCard({ src, jobId, status = 'done', onClick }: Prop
             width={1024}
             height={1024}
             alt="Generated image"
-            className="h-full w-full object-cover"
+            className="mx-auto max-h-[70vh] w-full max-w-full object-contain"
           />
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 transition duration-300 group-hover:opacity-100" />
         </>


### PR DESCRIPTION
## Summary
- limit image card previews with a flex container and max height so tall generations stay in view
- switch previews to object-contain and center them to avoid oversized vertical renders

## Testing
- npm run lint *(fails: next command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d4b37090832fb725b66d5d1844b2)